### PR TITLE
Disable implicit init py file creation for bazel python targets

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@ bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_java", version = "8.6.2")
 bazel_dep(name = "rules_jvm_external", version = "6.6")
-bazel_dep(name = "rules_python", version = "1.0.0")
+bazel_dep(name = "rules_python", version = "2.3.2")
 bazel_dep(name = "rules_kotlin", version = "2.0.0")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_proto", version = "7.1.0")
@@ -33,14 +33,14 @@ bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
     remote = "https://github.com/typedb/bazel-distribution",
-    commit = "dd811cf28715bbce8374e5e0f9defaf772e7dd36",
+    commit = "87a2092926b36a5c82cada9d21e1c3a6d6e32859",
 )
 
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")
 git_override(
     module_name = "typedb_dependencies",
     remote = "https://github.com/typedb/typedb-dependencies",
-    commit = "2e8abf8df1cd5a659f673396b8cfc53bd5d973cc",
+    commit = "bf924ef788fd605224383a2ea7f59599862c6bab",
 )
 
 bazel_dep(name = "typeql", version = "0.0.0")
@@ -78,6 +78,8 @@ python.toolchain(
     python_version = "3.11",
     ignore_root_user_error = True
 )
+rules_python_config = use_extension("@rules_python//python/extensions:config.bzl", "config")
+rules_python_config.explicit_init_py(default = True)
 
 # Rust rules need typedb_dependencies for patching
 bazel_dep(name = "rules_rust", version = "0.56.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -161,6 +161,7 @@
     "https://bcr.bazel.build/modules/package_metadata/0.0.10/source.json": "8fc6bece244828a69b3cc608f381118d67fa3cc2aa1a2851dfe8d99a8076d7d0",
     "https://bcr.bazel.build/modules/package_metadata/0.0.3/MODULE.bazel": "77890552ecea9e284b5424c9de827a58099348763a4359e975c359a83d4faa83",
     "https://bcr.bazel.build/modules/package_metadata/0.0.5/MODULE.bazel": "ef4f9439e3270fdd6b9fd4dbc3d2f29d13888e44c529a1b243f7a31dfbc2e8e4",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.7/MODULE.bazel": "7adb03933fc8401f495800cf4eafcff0edc6da0ff55c7db223ef69d19f689486",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
     "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
@@ -236,7 +237,8 @@
     "https://bcr.bazel.build/modules/rules_cc/0.2.13/MODULE.bazel": "eecdd666eda6be16a8d9dc15e44b5c75133405e820f620a234acc4b1fdc5aa37",
     "https://bcr.bazel.build/modules/rules_cc/0.2.14/MODULE.bazel": "353c99ed148887ee89c54a17d4100ae7e7e436593d104b668476019023b58df8",
     "https://bcr.bazel.build/modules/rules_cc/0.2.15/MODULE.bazel": "6a0a4a75a57aa6dc888300d848053a58c6b12a29f89d4304e1c41448514ec6e8",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.15/source.json": "197965c6dcca5c98a9288f93849e2e1c69d622e71b0be8deb524e22d48c88e32",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.17/MODULE.bazel": "1849602c86cb60da8613d2de887f9566a6d354a6df6d7009f9d04a14402f9a84",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.17/source.json": "3832f45d145354049137c0090df04629d9c2b5493dc5c2bf46f1834040133a07",
     "https://bcr.bazel.build/modules/rules_dotnet/0.14.0/MODULE.bazel": "f006f845f5e75c5a3e691947062bf33cfef66d2b66af9f1d5f6a35fc99d4ed78",
     "https://bcr.bazel.build/modules/rules_dotnet/0.14.0/source.json": "0fd3ac33da1afa98261a99251396e99eab82261739aa81beee6c814cc83b897e",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.10.1/MODULE.bazel": "b9527010e5fef060af92b6724edb3691970a5b1f76f74b21d39f7d433641be60",
@@ -337,7 +339,8 @@
     "https://bcr.bazel.build/modules/rules_python/1.6.0/MODULE.bazel": "7e04ad8f8d5bea40451cf80b1bd8262552aa73f841415d20db96b7241bd027d8",
     "https://bcr.bazel.build/modules/rules_python/2.0.0/MODULE.bazel": "1459089e2d4194d2a49e07896f5334fb230a8f2966ae945b1f793bef87a292fd",
     "https://bcr.bazel.build/modules/rules_python/2.0.1/MODULE.bazel": "294fbfe4dc3b24a925172e5487e1e8d3c2927cf4fba1eaddd7bad0ce50701da1",
-    "https://bcr.bazel.build/modules/rules_python/2.0.1/source.json": "f2bacc75d3fc496dfd3e6a5986200b10e70169aaaf4ee5f1cea573c8d347e7c4",
+    "https://bcr.bazel.build/modules/rules_python/2.3.2/MODULE.bazel": "5fdf04732b804f4e75011007ba91a68a37f6639665e2e5f8e26294cee1d56750",
+    "https://bcr.bazel.build/modules/rules_python/2.3.2/source.json": "40ebd885174966190b81190f00b0ab3af52dad0cd768624b26d27ac9f42567e2",
     "https://bcr.bazel.build/modules/rules_robolectric/4.14.1.2/MODULE.bazel": "d44fec647d0aeb67b9f3b980cf68ba634976f3ae7ccd6c07d790b59b87a4f251",
     "https://bcr.bazel.build/modules/rules_robolectric/4.14.1.2/source.json": "37c10335f2361c337c5c1f34ed36d2da70534c23088062b33a8bdaab68aa9dea",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
@@ -360,6 +363,8 @@
     "https://bcr.bazel.build/modules/stardoc/0.7.2/source.json": "58b029e5e901d6802967754adf0a9056747e8176f017cfe3607c0851f4d42216",
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/MODULE.bazel": "5e463fbfba7b1701d957555ed45097d7f984211330106ccd1352c6e0af0dcf91",
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/source.json": "32bd87e5f4d7acc57c5b2ff7c325ae3061d5e242c0c4c214ae87e0f1c13e54cb",
+    "https://bcr.bazel.build/modules/toml.bzl/0.4.1/MODULE.bazel": "6bc0b938f03ade8d58c2fca0ad5c3fa12b4764e1e1927ad50b0c860286db2167",
+    "https://bcr.bazel.build/modules/toml.bzl/0.4.1/source.json": "86a90afd8b43c9b69ad31f5c03998c3adcf4b08175e621addb93e3a38eec538b",
     "https://bcr.bazel.build/modules/toolchains_protoc/0.3.1/MODULE.bazel": "b6574a2a314cbd40cafb5ed87b03d1996e015315f80a7e33116c8b2e209cb5cf",
     "https://bcr.bazel.build/modules/toolchains_protoc/0.3.1/source.json": "b589ee1faec4c789c680afa9d500b5ccbea25422560b8b9dc4e0e6b26471f13b",
     "https://bcr.bazel.build/modules/upb/0.0.0-20211020-160625a/MODULE.bazel": "6cced416be2dc5b9c05efd5b997049ba795e5e4e6fafbe1624f4587767638928",
@@ -1308,8 +1313,8 @@
     },
     "@@rules_python+//python/uv:uv.bzl%uv": {
       "general": {
-        "bzlTransitiveDigest": "QNeVZtnuWz+doDJf60LFtYp/JPGDkFanzrjMd3gZSZI=",
-        "usagesDigest": "KI88AZslgI1K52IZ7PfBqhuXb5hke0gUD9N73XeVqaI=",
+        "bzlTransitiveDigest": "RrgJPyeWqGfORWwg4YW/6EjeQJZyDqTSte93bA4EEUU=",
+        "usagesDigest": "L3N4SM/V2B+19qn+nxXwA6j50ZDHvoKsdsifoTeMSWQ=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -5413,7 +5418,7 @@
     "@@typedb_dependencies+//distribution/artifact:rules.bzl%native_artifact_files": {
       "general": {
         "bzlTransitiveDigest": "j3hx3mUtu6z2mFVqzO+QxuHlrl18RFJ+k2KdWIGo83o=",
-        "usagesDigest": "p/tOBBn6sli1z31J+mJ/NEVv1o//ToaG1V5ookEFI8g=",
+        "usagesDigest": "5CMPr+yelU5phMuBoe70fFeqH101ui0+OUvcVOUv8LI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -5422,16 +5427,16 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-linux-arm64/versions/6fcf3bc075b3e19e1293edd3a878db22ced710c9/typedb-all-linux-arm64-6fcf3bc075b3e19e1293edd3a878db22ced710c9.tar.gz"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-linux-arm64/versions/86ca4aa944f664bae03cfdfa3367f6253ef97af5/typedb-all-linux-arm64-86ca4aa944f664bae03cfdfa3367f6253ef97af5.tar.gz"
               ],
-              "downloaded_file_path": "typedb-all-linux-arm64-6fcf3bc075b3e19e1293edd3a878db22ced710c9.tar.gz"
+              "downloaded_file_path": "typedb-all-linux-arm64-86ca4aa944f664bae03cfdfa3367f6253ef97af5.tar.gz"
             }
           },
           "typedb_artifact_linux-arm64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-linux-arm64/versions/6fcf3bc075b3e19e1293edd3a878db22ced710c9/typedb-all-linux-arm64-6fcf3bc075b3e19e1293edd3a878db22ced710c9.tar.gz"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-linux-arm64/versions/86ca4aa944f664bae03cfdfa3367f6253ef97af5/typedb-all-linux-arm64-86ca4aa944f664bae03cfdfa3367f6253ef97af5.tar.gz"
               ],
               "strip_prefix": "",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "
@@ -5441,16 +5446,16 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-linux-x86_64/versions/6fcf3bc075b3e19e1293edd3a878db22ced710c9/typedb-all-linux-x86_64-6fcf3bc075b3e19e1293edd3a878db22ced710c9.tar.gz"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-linux-x86_64/versions/86ca4aa944f664bae03cfdfa3367f6253ef97af5/typedb-all-linux-x86_64-86ca4aa944f664bae03cfdfa3367f6253ef97af5.tar.gz"
               ],
-              "downloaded_file_path": "typedb-all-linux-x86_64-6fcf3bc075b3e19e1293edd3a878db22ced710c9.tar.gz"
+              "downloaded_file_path": "typedb-all-linux-x86_64-86ca4aa944f664bae03cfdfa3367f6253ef97af5.tar.gz"
             }
           },
           "typedb_artifact_linux-x86_64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-linux-x86_64/versions/6fcf3bc075b3e19e1293edd3a878db22ced710c9/typedb-all-linux-x86_64-6fcf3bc075b3e19e1293edd3a878db22ced710c9.tar.gz"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-linux-x86_64/versions/86ca4aa944f664bae03cfdfa3367f6253ef97af5/typedb-all-linux-x86_64-86ca4aa944f664bae03cfdfa3367f6253ef97af5.tar.gz"
               ],
               "strip_prefix": "",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "
@@ -5460,16 +5465,16 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-mac-arm64/versions/6fcf3bc075b3e19e1293edd3a878db22ced710c9/typedb-all-mac-arm64-6fcf3bc075b3e19e1293edd3a878db22ced710c9.zip"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-mac-arm64/versions/86ca4aa944f664bae03cfdfa3367f6253ef97af5/typedb-all-mac-arm64-86ca4aa944f664bae03cfdfa3367f6253ef97af5.zip"
               ],
-              "downloaded_file_path": "typedb-all-mac-arm64-6fcf3bc075b3e19e1293edd3a878db22ced710c9.zip"
+              "downloaded_file_path": "typedb-all-mac-arm64-86ca4aa944f664bae03cfdfa3367f6253ef97af5.zip"
             }
           },
           "typedb_artifact_mac-arm64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-mac-arm64/versions/6fcf3bc075b3e19e1293edd3a878db22ced710c9/typedb-all-mac-arm64-6fcf3bc075b3e19e1293edd3a878db22ced710c9.zip"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-mac-arm64/versions/86ca4aa944f664bae03cfdfa3367f6253ef97af5/typedb-all-mac-arm64-86ca4aa944f664bae03cfdfa3367f6253ef97af5.zip"
               ],
               "strip_prefix": "",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "
@@ -5479,16 +5484,16 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-mac-x86_64/versions/6fcf3bc075b3e19e1293edd3a878db22ced710c9/typedb-all-mac-x86_64-6fcf3bc075b3e19e1293edd3a878db22ced710c9.zip"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-mac-x86_64/versions/86ca4aa944f664bae03cfdfa3367f6253ef97af5/typedb-all-mac-x86_64-86ca4aa944f664bae03cfdfa3367f6253ef97af5.zip"
               ],
-              "downloaded_file_path": "typedb-all-mac-x86_64-6fcf3bc075b3e19e1293edd3a878db22ced710c9.zip"
+              "downloaded_file_path": "typedb-all-mac-x86_64-86ca4aa944f664bae03cfdfa3367f6253ef97af5.zip"
             }
           },
           "typedb_artifact_mac-x86_64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-mac-x86_64/versions/6fcf3bc075b3e19e1293edd3a878db22ced710c9/typedb-all-mac-x86_64-6fcf3bc075b3e19e1293edd3a878db22ced710c9.zip"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-mac-x86_64/versions/86ca4aa944f664bae03cfdfa3367f6253ef97af5/typedb-all-mac-x86_64-86ca4aa944f664bae03cfdfa3367f6253ef97af5.zip"
               ],
               "strip_prefix": "",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "
@@ -5498,16 +5503,16 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-windows-x86_64/versions/6fcf3bc075b3e19e1293edd3a878db22ced710c9/typedb-all-windows-x86_64-6fcf3bc075b3e19e1293edd3a878db22ced710c9.zip"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-windows-x86_64/versions/86ca4aa944f664bae03cfdfa3367f6253ef97af5/typedb-all-windows-x86_64-86ca4aa944f664bae03cfdfa3367f6253ef97af5.zip"
               ],
-              "downloaded_file_path": "typedb-all-windows-x86_64-6fcf3bc075b3e19e1293edd3a878db22ced710c9.zip"
+              "downloaded_file_path": "typedb-all-windows-x86_64-86ca4aa944f664bae03cfdfa3367f6253ef97af5.zip"
             }
           },
           "typedb_artifact_windows-x86_64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-windows-x86_64/versions/6fcf3bc075b3e19e1293edd3a878db22ced710c9/typedb-all-windows-x86_64-6fcf3bc075b3e19e1293edd3a878db22ced710c9.zip"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-windows-x86_64/versions/86ca4aa944f664bae03cfdfa3367f6253ef97af5/typedb-all-windows-x86_64-86ca4aa944f664bae03cfdfa3367f6253ef97af5.zip"
               ],
               "strip_prefix": "",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "
@@ -5517,16 +5522,16 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-linux-arm64/versions/48f59129a4e9101221ce1d0f23f4fad1fb34b538/typedb-cluster-all-linux-arm64-48f59129a4e9101221ce1d0f23f4fad1fb34b538.tar.gz"
+                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-linux-arm64/versions/a0c9375298893ee82fabbb0f8ebd6961b51c277a/typedb-cluster-all-linux-arm64-a0c9375298893ee82fabbb0f8ebd6961b51c277a.tar.gz"
               ],
-              "downloaded_file_path": "typedb-cluster-all-linux-arm64-48f59129a4e9101221ce1d0f23f4fad1fb34b538.tar.gz"
+              "downloaded_file_path": "typedb-cluster-all-linux-arm64-a0c9375298893ee82fabbb0f8ebd6961b51c277a.tar.gz"
             }
           },
           "typedb_cluster_artifact_linux-arm64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-linux-arm64/versions/48f59129a4e9101221ce1d0f23f4fad1fb34b538/typedb-cluster-all-linux-arm64-48f59129a4e9101221ce1d0f23f4fad1fb34b538.tar.gz"
+                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-linux-arm64/versions/a0c9375298893ee82fabbb0f8ebd6961b51c277a/typedb-cluster-all-linux-arm64-a0c9375298893ee82fabbb0f8ebd6961b51c277a.tar.gz"
               ],
               "strip_prefix": "",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "
@@ -5536,16 +5541,16 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-linux-x86_64/versions/48f59129a4e9101221ce1d0f23f4fad1fb34b538/typedb-cluster-all-linux-x86_64-48f59129a4e9101221ce1d0f23f4fad1fb34b538.tar.gz"
+                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-linux-x86_64/versions/a0c9375298893ee82fabbb0f8ebd6961b51c277a/typedb-cluster-all-linux-x86_64-a0c9375298893ee82fabbb0f8ebd6961b51c277a.tar.gz"
               ],
-              "downloaded_file_path": "typedb-cluster-all-linux-x86_64-48f59129a4e9101221ce1d0f23f4fad1fb34b538.tar.gz"
+              "downloaded_file_path": "typedb-cluster-all-linux-x86_64-a0c9375298893ee82fabbb0f8ebd6961b51c277a.tar.gz"
             }
           },
           "typedb_cluster_artifact_linux-x86_64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-linux-x86_64/versions/48f59129a4e9101221ce1d0f23f4fad1fb34b538/typedb-cluster-all-linux-x86_64-48f59129a4e9101221ce1d0f23f4fad1fb34b538.tar.gz"
+                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-linux-x86_64/versions/a0c9375298893ee82fabbb0f8ebd6961b51c277a/typedb-cluster-all-linux-x86_64-a0c9375298893ee82fabbb0f8ebd6961b51c277a.tar.gz"
               ],
               "strip_prefix": "",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "
@@ -5555,16 +5560,16 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-mac-arm64/versions/48f59129a4e9101221ce1d0f23f4fad1fb34b538/typedb-cluster-all-mac-arm64-48f59129a4e9101221ce1d0f23f4fad1fb34b538.zip"
+                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-mac-arm64/versions/a0c9375298893ee82fabbb0f8ebd6961b51c277a/typedb-cluster-all-mac-arm64-a0c9375298893ee82fabbb0f8ebd6961b51c277a.zip"
               ],
-              "downloaded_file_path": "typedb-cluster-all-mac-arm64-48f59129a4e9101221ce1d0f23f4fad1fb34b538.zip"
+              "downloaded_file_path": "typedb-cluster-all-mac-arm64-a0c9375298893ee82fabbb0f8ebd6961b51c277a.zip"
             }
           },
           "typedb_cluster_artifact_mac-arm64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-mac-arm64/versions/48f59129a4e9101221ce1d0f23f4fad1fb34b538/typedb-cluster-all-mac-arm64-48f59129a4e9101221ce1d0f23f4fad1fb34b538.zip"
+                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-mac-arm64/versions/a0c9375298893ee82fabbb0f8ebd6961b51c277a/typedb-cluster-all-mac-arm64-a0c9375298893ee82fabbb0f8ebd6961b51c277a.zip"
               ],
               "strip_prefix": "",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "
@@ -5574,16 +5579,16 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-mac-x86_64/versions/48f59129a4e9101221ce1d0f23f4fad1fb34b538/typedb-cluster-all-mac-x86_64-48f59129a4e9101221ce1d0f23f4fad1fb34b538.zip"
+                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-mac-x86_64/versions/a0c9375298893ee82fabbb0f8ebd6961b51c277a/typedb-cluster-all-mac-x86_64-a0c9375298893ee82fabbb0f8ebd6961b51c277a.zip"
               ],
-              "downloaded_file_path": "typedb-cluster-all-mac-x86_64-48f59129a4e9101221ce1d0f23f4fad1fb34b538.zip"
+              "downloaded_file_path": "typedb-cluster-all-mac-x86_64-a0c9375298893ee82fabbb0f8ebd6961b51c277a.zip"
             }
           },
           "typedb_cluster_artifact_mac-x86_64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-mac-x86_64/versions/48f59129a4e9101221ce1d0f23f4fad1fb34b538/typedb-cluster-all-mac-x86_64-48f59129a4e9101221ce1d0f23f4fad1fb34b538.zip"
+                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-mac-x86_64/versions/a0c9375298893ee82fabbb0f8ebd6961b51c277a/typedb-cluster-all-mac-x86_64-a0c9375298893ee82fabbb0f8ebd6961b51c277a.zip"
               ],
               "strip_prefix": "",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "
@@ -5593,16 +5598,16 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-windows-x86_64/versions/48f59129a4e9101221ce1d0f23f4fad1fb34b538/typedb-cluster-all-windows-x86_64-48f59129a4e9101221ce1d0f23f4fad1fb34b538.zip"
+                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-windows-x86_64/versions/a0c9375298893ee82fabbb0f8ebd6961b51c277a/typedb-cluster-all-windows-x86_64-a0c9375298893ee82fabbb0f8ebd6961b51c277a.zip"
               ],
-              "downloaded_file_path": "typedb-cluster-all-windows-x86_64-48f59129a4e9101221ce1d0f23f4fad1fb34b538.zip"
+              "downloaded_file_path": "typedb-cluster-all-windows-x86_64-a0c9375298893ee82fabbb0f8ebd6961b51c277a.zip"
             }
           },
           "typedb_cluster_artifact_windows-x86_64-extracted": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-windows-x86_64/versions/48f59129a4e9101221ce1d0f23f4fad1fb34b538/typedb-cluster-all-windows-x86_64-48f59129a4e9101221ce1d0f23f4fad1fb34b538.zip"
+                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-windows-x86_64/versions/a0c9375298893ee82fabbb0f8ebd6961b51c277a/typedb-cluster-all-windows-x86_64-a0c9375298893ee82fabbb0f8ebd6961b51c277a.zip"
               ],
               "strip_prefix": "",
               "build_file_content": "\nfilegroup(\n    name = \"all_files\",\n    srcs = glob([\"**/*\"]),\n    visibility = [\"//visibility:public\"],\n)\n                        "


### PR DESCRIPTION
## Usage and product changes
Disable implicit init py file creation for bazel python targets, as advised by: https://github.com/bazel-contrib/rules_python/issues/2945 

## Implementation
Configures this repo to disable the behaviour, as advised by the error message: 
```
rules_python_config = use_extension("@rules_python//python/extensions:config.bzl", "config")
rules_python_config.explicit_init_py(default = True)
```

Note this only influences targets in this repository, so we still get warnings from other dependencies such as `bazel_tools` and `rules_pkg`.